### PR TITLE
Changed bucket policy to depend on length of app account number list

### DIFF
--- a/s3-tstate.tf
+++ b/s3-tstate.tf
@@ -7,7 +7,7 @@ module "s3-tstate" {
   block_public_acls       = true
   ignore_public_acls      = true
   restrict_public_buckets = true
-  bucket_policy           = true
+  bucket_policy           = length([for account in var.application_account_numbers : account if account != ""]) > 0
   aws_iam_policy_document = data.aws_iam_policy_document.tfstate_bucket_policy.json
 
   lifecycle_configuration_rules = [

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,6 @@ variable "resource_prefix" {
 variable "application_account_numbers" {
   description = "Account IDs for application accounts to be used in IAM"
   type        = list(string)
-
 }
 
 variable "dynamo_kms_key_arn" {


### PR DESCRIPTION
Updated bucket policy to be conditional based on if there are account numbers passed in the application_account_numbers var when calling the module. There was a KMS key creation error occurring when an empty list was passed (check Harrison's open issue in account setup repo). Tested this successfully in Coalfire GovCloud sandbox.