### PR TITLE
Update s3 module to remove default lifecycle rules.

### DIFF
--- a/s3-tstate.tf
+++ b/s3-tstate.tf
@@ -1,5 +1,5 @@
 module "s3-tstate" {
-  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.1"
+  source = "github.com/Coalfire-CF/terraform-aws-s3?ref=v1.0.4"
 
   name                    = "${var.resource_prefix}-${var.aws_region}-tf-state"
   kms_master_key_id       = var.s3_kms_key_arn
@@ -9,17 +9,4 @@ module "s3-tstate" {
   restrict_public_buckets = true
   bucket_policy           = length([for account in var.application_account_numbers : account if account != ""]) > 0
   aws_iam_policy_document = data.aws_iam_policy_document.tfstate_bucket_policy.json
-
-  lifecycle_configuration_rules = [
-    {
-      id      = "default"
-      enabled = true
-
-      enable_glacier_transition            = false
-      enable_current_object_expiration     = false
-      enable_noncurrent_version_expiration = false
-
-      abort_incomplete_multipart_upload_days = 1
-    }
-  ]
 }


### PR DESCRIPTION
- Updates s3 module from v1.0.1 => v1.0.4.
- Removed default lifecycle rules (default is no lifecycle rules).

This is intended to prevent terraform state objects moving to Glacier or getting deleted over time.